### PR TITLE
feat: support null description in SkillForProject.

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -149,7 +149,7 @@ export interface SkillForUser {
  */
 export interface SkillForProject {
   id: string;
-  description: string;
+  description: string | null;
 
   // The unique ID of the SkillForUser associated with this project.
   skillForUser: SkillForUser;


### PR DESCRIPTION
## Description

While setting up dummy data for the OpenResume project's AI feature, I noticed TypeScript errors when `null` was provided for the `skillForProject.description` values.

This PR should fix that issue.