### PR TITLE
feat: support count types in definitions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "openresume-theme",
+  "name": "@openresume/theme",
   "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "openresume-theme",
+      "name": "@openresume/theme",
       "version": "0.1.7",
       "license": "MIT",
       "dependencies": {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -180,6 +180,9 @@ export interface Company {
   // The positions associated with this company, which can contain one or more positions.
   // This can help show the user's progression within the company, or if they held multiple roles.
   positions?: Position[];
+
+  // The total number of positions associated with this company.
+  positionCount?: number;
 }
 
 /**
@@ -198,6 +201,9 @@ export interface Position {
 
   // The projects associated with this position, which can contain one or more projects.
   projects?: Project[];
+
+  // The total number of projects associated with this position.
+  projectCount?: number;
 }
 
 /**


### PR DESCRIPTION
## Description

In the OpenResume backend, there's a need to conditionally render some UI elements based on the number of records in a query. The type support needs to be available in this package.